### PR TITLE
Feat/jwtforcontroller

### DIFF
--- a/src/main/java/com/spartaboys/newsfeed/domain/auth/BearerTokenResolver.java
+++ b/src/main/java/com/spartaboys/newsfeed/domain/auth/BearerTokenResolver.java
@@ -1,0 +1,20 @@
+package com.spartaboys.newsfeed.domain.auth;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BearerTokenResolver {
+
+    //Bearer 뺀 토큰 검증
+    private BearerTokenResolver() {}
+    public static String resolve(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header == null) return null;
+        String[] parts = header.split("\\s+", 2); // "Bearer <token>"
+        if (parts.length != 2 || !parts[0].equalsIgnoreCase("Bearer")) return null;
+        return parts[1].isEmpty() ? null : parts[1];
+    }
+}

--- a/src/main/java/com/spartaboys/newsfeed/domain/auth/FilterConfig.java
+++ b/src/main/java/com/spartaboys/newsfeed/domain/auth/FilterConfig.java
@@ -1,0 +1,18 @@
+package com.spartaboys.newsfeed.domain.auth;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfig {
+
+    @Bean
+    public FilterRegistrationBean<TokenFilter> tokenFilterRegistration(TokenFilter filter) {
+        var reg = new FilterRegistrationBean<>(filter);
+        reg.setOrder(1);                       // 우선순위
+        reg.addUrlPatterns("/me", "/auth/logout");
+        return reg;
+    }
+}
+

--- a/src/main/java/com/spartaboys/newsfeed/domain/auth/JWTConstant.java
+++ b/src/main/java/com/spartaboys/newsfeed/domain/auth/JWTConstant.java
@@ -1,0 +1,8 @@
+package com.spartaboys.newsfeed.domain.auth;
+
+public interface JWTConstant {
+
+    String JWT_SECRET = "super-secret-key-change-me-32bytes-minimum-aaaaaaaaaaaa";
+    long ACCESS_EXP_MS = 15 * 60 * 1000L;
+
+}

--- a/src/main/java/com/spartaboys/newsfeed/domain/auth/JwtConfig.java
+++ b/src/main/java/com/spartaboys/newsfeed/domain/auth/JwtConfig.java
@@ -1,0 +1,18 @@
+package com.spartaboys.newsfeed.domain.auth;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+@Configuration
+public class JwtConfig {
+
+    @Bean
+    public JwtVerifier jwtVerifier(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.clock-skew-seconds:60}") long skewSec
+    ) {
+        return new JwtVerifier(secret, null, null, skewSec);
+    }
+}

--- a/src/main/java/com/spartaboys/newsfeed/domain/auth/JwtTokenFilter.java
+++ b/src/main/java/com/spartaboys/newsfeed/domain/auth/JwtTokenFilter.java
@@ -29,11 +29,11 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 
         String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-        //header 값이 비었을 때
-        if (authorizationHeader == null) {
-            filterChain.doFilter(request, response); // dofilter를 사용해서 예외처리
-            return;
-        }
+//        //header 값이 비었을 때
+//        if (authorizationHeader == null) {
+//            filterChain.doFilter(request, response); // dofilter를 사용해서 예외처리
+//            return;
+//        }
 
         //header의 Authorization 값이 'Bearer ' 로 시작하지 않을때
         if (!authorizationHeader.startsWith("Bearer")) {
@@ -55,8 +55,8 @@ public class JwtTokenFilter extends OncePerRequestFilter {
                 filterChain.doFilter(request, response);
                 return;
             }
-            String loginId = JwtTokenUtil.getLoginId(token, secretKey);
-            User loginUser = accessService.getLoginUserByLoginId(loginId);
+            String email = JwtTokenUtil.getLoginId(token, secretKey);
+            User loginUser = accessService.findByEmail(email);
             if (loginUser == null) {
                 filterChain.doFilter(request, response);
                 return;
@@ -66,17 +66,11 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             return;
         }
 
-        // Jwt Token에서 loginId 추출
-        String loginId = JwtTokenUtil.getLoginId(token, secretKey);
+        // Jwt Token에서 email 추출
+        String email = JwtTokenUtil.getLoginId(token, secretKey);
 
-        // 추출한 LoginiId로 User 찾아오기
-        User loginUser = accessService.getLoginUserByLoginId(loginId);
-
-
-
-        //loginUser 정보로 UsernamePasswordAuthenticationToken 발급
-
+        // 추출한 email로 User 찾아오기
+        User loginUser = accessService.findByEmail(email);
 
     }
-
 }

--- a/src/main/java/com/spartaboys/newsfeed/domain/auth/JwtTokenUtil.java
+++ b/src/main/java/com/spartaboys/newsfeed/domain/auth/JwtTokenUtil.java
@@ -3,6 +3,8 @@ package com.spartaboys.newsfeed.domain.auth;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -10,13 +12,13 @@ import java.util.Date;
 // Jwt 활용할 기능들 정리  토큰 생성.
 public class JwtTokenUtil {
 
-    public static String createToken(String loginId, String key, long expireTimeMs){
+    public static String createToken(String nickName, String key, long expireTimeMs){
 
         // Claim = Jwt Token에 들어갈 정보
         Date now = new Date();
         Claims claims = Jwts.claims();
-        claims.put("loginId", loginId);
-        claims.setSubject(loginId);
+        claims.put("nickName", nickName);
+        claims.setSubject(nickName);
 
         return Jwts.builder()
                 .setClaims(claims)
@@ -28,6 +30,7 @@ public class JwtTokenUtil {
 
     // Claims에서 loginId 꺼내기
     public static String getLoginId(String token, String secretKey){
+
         return extractClaims(token, secretKey).get("loginId", String.class);
     }
 
@@ -45,4 +48,5 @@ public class JwtTokenUtil {
                 .parseClaimsJws(token)
                 .getBody();
     }
+
 }

--- a/src/main/java/com/spartaboys/newsfeed/domain/auth/JwtVerifier.java
+++ b/src/main/java/com/spartaboys/newsfeed/domain/auth/JwtVerifier.java
@@ -1,0 +1,43 @@
+package com.spartaboys.newsfeed.domain.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+
+@Slf4j
+public class JwtVerifier {
+    private final Key key;
+    private final long clockSkewSeconds;
+
+    private static String hash12(String s){
+        try {
+            var md = java.security.MessageDigest.getInstance("SHA-256");
+            var d  = md.digest(s.getBytes(StandardCharsets.UTF_8));
+            return java.util.Base64.getEncoder().encodeToString(d).substring(0, 12);
+        } catch (Exception e) { return "NA"; }
+    }
+
+    public JwtVerifier(String secret, String issuerIgnored, String audIgnored, long skewSec) {
+        // 공백/개행 제거
+        secret = secret == null ? "" : secret.trim();
+
+        // 생성/검증 동일성 확인용 로그 (길이 + 해시)
+        log.info("[JWT-VER] secretLen={}, secretHash={}", secret.length(), hash12(secret));
+
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.clockSkewSeconds = skewSec;
+    }
+
+    public Claims verifyAndGetClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .setAllowedClockSkewSeconds(clockSkewSeconds)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/com/spartaboys/newsfeed/domain/auth/RestTemplateConfig.java
+++ b/src/main/java/com/spartaboys/newsfeed/domain/auth/RestTemplateConfig.java
@@ -1,0 +1,92 @@
+package com.spartaboys.newsfeed.domain.auth;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Objects;
+
+@Configuration
+public class RestTemplateConfig {
+
+    private static final String ACCESS_TOKEN_COOKIE = "ACCESS_TOKEN"; // 쿠키 이름을 네가 사용 중인 이름으로 맞춰줘
+
+    @Bean
+    public RestTemplate restTemplate() {
+        RestTemplate rt = new RestTemplate();
+
+        rt.getInterceptors().add((request, body, execution) -> {
+            String bearer = currentBearer(); // "Bearer xxx" 또는 null
+            if (bearer != null) {
+                request.getHeaders().set(HttpHeaders.AUTHORIZATION, bearer);
+            }
+            return execution.execute(request, body);
+        });
+
+        return rt;
+    }
+
+    /**
+     * 현재 쓰레드의 HTTP 요청 컨텍스트에서 Bearer 토큰을 찾아 "Bearer xxx" 형태로 반환.
+     * 우선순위: Authorization 헤더 → ACCESS_TOKEN 쿠키 → (선택) Request Attribute
+     */
+    private String currentBearer() {
+        ServletRequestAttributes attrs =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attrs == null) return null;
+
+        HttpServletRequest req = attrs.getRequest();
+
+        // 1) Authorization 헤더 그대로 사용 (이미 "Bearer xxx" 형태일 것)
+        String h = headerIgnoreCase(req, HttpHeaders.AUTHORIZATION);
+        if (h != null && !h.isBlank()) {
+            return h.trim();
+        }
+
+        // 2) 쿠키에서 액세스 토큰 사용 (쿠키명은 프로젝트에 맞춰 수정)
+        String token = tokenFromCookie(req, ACCESS_TOKEN_COOKIE);
+        if (token != null) {
+            return "Bearer " + token;
+        }
+
+        // 3) (옵션) 필터에서 저장해둔 요청 어트리뷰트가 있다면 사용
+        Object raw = req.getAttribute("CURRENT_USER_TOKEN");
+        if (raw instanceof String s && !s.isBlank()) {
+            return s.startsWith("Bearer ") ? s : ("Bearer " + s);
+        }
+
+        return null;
+    }
+
+    private static String headerIgnoreCase(HttpServletRequest req, String name) {
+        Enumeration<String> names = req.getHeaderNames();
+        if (names == null) return null;
+        while (names.hasMoreElements()) {
+            String n = names.nextElement();
+            if (name.equalsIgnoreCase(n)) {
+                return req.getHeader(n);
+            }
+        }
+        return null;
+    }
+
+    private static String tokenFromCookie(HttpServletRequest req, String cookieName) {
+        Cookie[] cookies = req.getCookies();
+        if (cookies == null) return null;
+        for (Cookie c : cookies) {
+            if (Objects.equals(cookieName, c.getName()) && c.getValue() != null && !c.getValue().isBlank()) {
+                return c.getValue().trim();
+            }
+        }
+        return null;
+    }
+}
+
+

--- a/src/main/java/com/spartaboys/newsfeed/domain/auth/TokenFilter.java
+++ b/src/main/java/com/spartaboys/newsfeed/domain/auth/TokenFilter.java
@@ -1,0 +1,94 @@
+package com.spartaboys.newsfeed.domain.auth;
+
+import com.spartaboys.newsfeed.domain.auth.dto.UserPrincipal;
+import com.spartaboys.newsfeed.domain.users.entity.User;
+import com.spartaboys.newsfeed.domain.users.repository.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import io.jsonwebtoken.Claims;
+import java.io.IOException;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenFilter extends OncePerRequestFilter {
+
+    private final JwtVerifier verifier;
+    private final UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+
+        log.info("AuthH={}", request.getHeader(HttpHeaders.AUTHORIZATION));
+
+        String token = BearerTokenResolver.resolve(request);
+
+        if (token == null) {
+            unauthorized(response, "Authorization 헤더가 없습니다.");
+            return;
+        }
+
+        try {
+            Claims c = verifier.verifyAndGetClaims(token);
+
+            // 1) 토큰에서 닉네임 추출
+            String nickname = c.getSubject(); // sub=nickname 기준
+            if (nickname == null || nickname.isBlank()) {
+                unauthorized(response, "유효한 사용자 식별자가 없습니다."); return;
+            }
+
+            // 2) 닉네임으로 사용자 대조 (중복/변경 이슈는 감안)
+            Optional<User> user = userRepository.findByNickname(nickname);
+            if (user == null) {
+                unauthorized(response, "유효한 사용자 식별자가 없습니다."); return;
+            }
+
+            // 3) Principal 세팅
+            UserPrincipal principal = new UserPrincipal(user.get().getId(), user.get().getNickname());
+            request.setAttribute("CURRENT_USER", principal);
+            chain.doFilter(request, response);
+
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            log.warn("JWT expired at {}", e.getClaims().getExpiration(), e);
+            unauthorized(response, "토큰이 만료되었습니다.");
+        } catch (io.jsonwebtoken.SignatureException e) {
+            log.warn("JWT signature invalid", e);
+            unauthorized(response, "서명이 유효하지 않습니다.");
+        } catch (io.jsonwebtoken.MalformedJwtException | io.jsonwebtoken.UnsupportedJwtException e) {
+            log.warn("JWT malformed/unsupported", e);
+            unauthorized(response, "토큰 형식이 잘못되었습니다.");
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT empty/illegal", e);
+            unauthorized(response, "토큰이 비어있습니다.");
+        }
+    }
+
+    private void unauthorized(HttpServletResponse res, String msg) throws IOException {
+        res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        res.setContentType("application/json;charset=UTF-8");
+        res.getWriter().write("{\"message\":\"" + msg + "\"}");
+    }
+
+    private static Long claimAsLong(Claims c, String name) {
+        Object v = c.get(name);
+        if (v == null) return null;
+        if (v instanceof Number n) return n.longValue();
+        try { return Long.parseLong(v.toString()); } catch (Exception ignore) { return null; }
+    }
+
+    private static Long parseLongSafe(String s) {
+        try { return (s == null) ? null : Long.parseLong(s); }
+        catch (Exception e) { return null; }
+    }
+}

--- a/src/main/java/com/spartaboys/newsfeed/domain/auth/controller/AccessController.java
+++ b/src/main/java/com/spartaboys/newsfeed/domain/auth/controller/AccessController.java
@@ -1,12 +1,16 @@
 package com.spartaboys.newsfeed.domain.auth.controller;
 
+import com.spartaboys.newsfeed.domain.auth.JWTConstant;
 import com.spartaboys.newsfeed.domain.auth.dto.*;
 import com.spartaboys.newsfeed.domain.auth.JwtTokenUtil;
 import com.spartaboys.newsfeed.domain.auth.service.AccessService;
 import com.spartaboys.newsfeed.domain.users.entity.User;
+import jakarta.security.auth.message.AuthException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,46 +23,46 @@ public class AccessController {
 
     private final AccessService accessService;
 
-    //    @Value("${jwt.secretKey}") //
-//    String JWT_SECRET;
-    private static final String JWT_SECRET = "super-secret-key-change-me-32bytes-minimum-aaaaaaaaaaaa";
-    private static final long ACCESS_EXP_MS = 15 * 60 * 1000L;
-
     @PostMapping("/sign-in")
     public ResponseEntity<?> login(@RequestBody LoginRequest loginRequest,
-                                   HttpServletRequest request) {
+                                   HttpServletRequest request) throws AuthException {
 
         LoginResponse response = accessService.login(loginRequest);
 
         //로그인 아이디를 받아서 회원 정보 조회 -> 없을시 예외처리
-        User user = accessService.findByLoginId(loginRequest.getEmail());
+        User user = accessService.findByEmail(loginRequest.getEmail());
 
         // 로그인 아이디나 비밀번호가 틀린 경우 -> 예외처리
         if (user == null) {
             return ResponseEntity.status(401).body(Map.of("message","로그인 아이디 또는 비밀번호가 틀렸습니다"));
         }
 
-        //비밀번호 검증
-
-        //JWT 토큰 생성
-
         // 서명 과 완료를 JWTToken에 부여
-        String accessToken = JwtTokenUtil.createToken(user.getEmail(), JWT_SECRET, ACCESS_EXP_MS);
+        String accessToken = JwtTokenUtil.createToken(user.getEmail(),
+                JWTConstant.JWT_SECRET ,
+                JWTConstant.ACCESS_EXP_MS);
         long expireTimesMs = 1000 * 60 * 60; // 토큰 유효 시간
 
         // String token = JwtTokenUtil.createToken(user.getLoginId(), accessToken , expireTimesMs);
 
-        //세션에 저장
-        HttpSession session = request.getSession(true);
-        session.setAttribute("LOGIN_USER_ID", user.getId());
-        session.setAttribute("LOGIN_ID", user.getEmail());
+       //세션에 저장
+//        HttpSession session = request.getSession(true);
+//        session.setAttribute("LOGIN_USER_ID", user.getId());
+//        session.setAttribute("LOGIN_ID", user.getEmail());
+
+        String token = (String) request.getAttribute("JWT_TOKEN");
+
+        System.out.println(token);
 
         // Map 그대로 반환 Json
-        return ResponseEntity.ok(Map.of(
-                "tokenType","Bearer",
-                "accessToken", response.getToken(),
-                "expiresIn", expireTimesMs / 1000 * 60 * 60
-        ));
+        return ResponseEntity.ok()
+                .header(HttpHeaders.AUTHORIZATION,"Bearer " + accessToken)
+                .body(Map.of("tokenType","Bearer","accessToken", accessToken));
+//        Map.of(
+//               "tokenType","Bearer",
+//               "accessToken", response.getToken(),
+//                "expiresIn", expireTimesMs / 1000 * 60 * 60
+//        )
     }
 
     @PostMapping("/sign-up")

--- a/src/main/java/com/spartaboys/newsfeed/domain/auth/controller/MeController.java
+++ b/src/main/java/com/spartaboys/newsfeed/domain/auth/controller/MeController.java
@@ -1,0 +1,12 @@
+package com.spartaboys.newsfeed.domain.auth.controller;
+import com.spartaboys.newsfeed.domain.auth.dto.UserPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class MeController {
+
+    @GetMapping("/me")
+    public UserPrincipal me(@RequestAttribute("CURRENT_USER") UserPrincipal me) {
+        return me; // me.id(), me.email() 등 사용
+    }
+}

--- a/src/main/java/com/spartaboys/newsfeed/domain/auth/dto/UserPrincipal.java
+++ b/src/main/java/com/spartaboys/newsfeed/domain/auth/dto/UserPrincipal.java
@@ -1,0 +1,15 @@
+package com.spartaboys.newsfeed.domain.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserPrincipal {
+
+    private final Long id;
+    private final String nickname;
+
+    public UserPrincipal(Long id, String nickname) {
+        this.id = id;
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/spartaboys/newsfeed/domain/auth/dto/UserSignUpResponse.java
+++ b/src/main/java/com/spartaboys/newsfeed/domain/auth/dto/UserSignUpResponse.java
@@ -8,13 +8,13 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 public class UserSignUpResponse {
 
     String userName;
     String email;
 
-    public UserSignUpResponse(@Email @NotBlank String email, @NotBlank(message = "회원 이름은 필수 입력값입니다.") String username, @Email @NotBlank String email1) {
-
+    public UserSignUpResponse(String email, String userName) {
+        this.email = email;
+        this.userName = userName;
     }
 }

--- a/src/main/java/com/spartaboys/newsfeed/domain/auth/repository/AccessRepository.java
+++ b/src/main/java/com/spartaboys/newsfeed/domain/auth/repository/AccessRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 @Repository
 public interface AccessRepository extends JpaRepository<User,Long> {
 
-    Optional<User> findByEmail(String email);
+    User findByEmail(String email);
 
     boolean existsByEmail(String email);
 

--- a/src/main/java/com/spartaboys/newsfeed/domain/auth/service/AccessService.java
+++ b/src/main/java/com/spartaboys/newsfeed/domain/auth/service/AccessService.java
@@ -1,5 +1,6 @@
 package com.spartaboys.newsfeed.domain.auth.service;
 
+import com.spartaboys.newsfeed.domain.auth.JWTConstant;
 import com.spartaboys.newsfeed.domain.auth.dto.*;
 import com.spartaboys.newsfeed.domain.auth.JwtTokenUtil;
 import com.spartaboys.newsfeed.domain.auth.PasswordEncoder;
@@ -23,20 +24,9 @@ public class AccessService {
 
     //loginId로 엔티티를 호출 없을시에는 예외 처리
     @Transactional(readOnly = true)
-    public User findByLoginId(String email) {
+    public User findByEmail(String email) {
 
-        return accessRepository.findByEmail(email)
-
-
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-    }
-
-    // LoginId를 통해서 유저찾기
-    @Transactional(readOnly = true)
-    public User getLoginUserByLoginId(String email) {
-
-        return accessRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 로그인 아이디입니다."));
+        return accessRepository.findByEmail(email);
     }
 
     @Transactional
@@ -57,32 +47,37 @@ public class AccessService {
 
         User saved = accessRepository.save(user);
 
-        return new UserSignUpResponse(user.getEmail(), request.getUsername(), user.getEmail());
+        return new UserSignUpResponse(user.getEmail(), request.getUsername());
     }
 
     @Transactional(readOnly = true)
     public LoginResponse login(LoginRequest loginRequest) {
 
-        User user = getLoginUserByLoginId(loginRequest.getEmail());
+        User byEmail = accessRepository.findByEmail(loginRequest.getEmail());
 
-        String token = JwtTokenUtil.createToken(user.getEmail(),
-                "super-secret-key-change-me-32bytes-minimum-aaaaaaaaaaaa",
-                15 * 60 * 1000L);
+        if (byEmail == null){
+            throw new IllegalArgumentException("아이디가 맞지 않습니다.");
+        }
+
+        if (!passwordEncoder.matches(loginRequest.getPassword(),byEmail.getPassword())){
+            throw new IllegalArgumentException("비밀번호가 맞지 않습니다.");
+        }
+
+        String token = JwtTokenUtil.createToken(byEmail.getEmail(),
+                JWTConstant.JWT_SECRET,
+               JWTConstant.ACCESS_EXP_MS);
 
 
-        return new LoginResponse(user.getEmail(), token);
+        return new LoginResponse(byEmail.getEmail(), token);
     }
 
     @Transactional
     public void deleteUserByPassword(DeleteRequestUser deleteRequestUser) {
-        Optional<User> user = Optional.ofNullable(accessRepository.findByEmail(deleteRequestUser.getEmail())
-                .orElseThrow(() -> new IllegalArgumentException()));
+        Optional<User> user = Optional.ofNullable(accessRepository.findByEmail(deleteRequestUser.getEmail()));
 
-        System.out.println("회원탈퇴를 위해서 비밀번호를 다시 입력해주세요.");
         if (!passwordEncoder.matches(deleteRequestUser.getPassword(), user.get().getPassword())) {
             throw new IllegalArgumentException("비밀번호가 맞지 않습니다.");
         }
-
 
         accessRepository.deleteById(user.get().getId());
     }

--- a/src/main/java/com/spartaboys/newsfeed/domain/boards/repository/BoardRepository.java
+++ b/src/main/java/com/spartaboys/newsfeed/domain/boards/repository/BoardRepository.java
@@ -4,6 +4,7 @@ import com.spartaboys.newsfeed.domain.boards.entity.Board;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
     Page<Board> findAllByTitle(String title, Pageable pageable);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,11 @@
 spring:
   application:
     name: NewsFeed
-  config:
-    import: optional:file:.env[.properties]
+
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: jdbc:mysql://localhost:3306/newsfeed
+    username: root
+    password: "000620"
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:


### PR DESCRIPTION
컨트롤러에서 사용할수 있도록 me 컨트롤러로 유저정보를 옮겨서 사용할 수 있도록 만들어보았습니다.
어제 동일한 서명이 아니라는 오류가 발생해서 동일한 닉네임으로 넣어서 인증을 가능하도록 했을때 포스트맨에서 작동이 되었다가 pull 이후에 코드가 안돌아가는 이유는 모르겠습니다.

우선 주요 수정내역은 다음과 같습니다.

meController -> 유저정보를 전달
TokenFilter -> 토큰 검증
JwtVerifier -> 토큰 검증을 이용해서 식별
JwtUtil -> 토큰 빌더

만약 프로그램이 실행이 안된다면 yml 파일에

jwt:
  secret: THIS_IS_AT_LEAST_32_BYTES_LONG_SECRET_1234_5678
  clock-skew-seconds: 60

를 입력하시면 될거 같습니다.
